### PR TITLE
docs(readme): link to correct contributing file in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Go client is currently maintained by @steebchen and considered to be in alph
 
 ## Contributing
 
-Check out the [advanced contributing guide](./CONTRIBUTING).
+Check out the [advanced contributing guide](./CONTRIBUTING.md).
 
 ## Security
 


### PR DESCRIPTION
Use correct link to contributing guide in README.md.