### PR TITLE
chore(prisma): upgrade prisma to v5.5.0

### DIFF
--- a/binaries/binaries.go
+++ b/binaries/binaries.go
@@ -14,11 +14,11 @@ import (
 )
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.4.2"
+const PrismaVersion = "5.5.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "ac9d7041ed77bcc8a8dbd2ab6616b39013829574"
+const EngineVersion = "475c616176945d72f4330c92801f0c5e6398dc0f"
 
 // PrismaURL points to an S3 bucket URL where the CLI binaries are stored.
 var PrismaURL = "https://packaged-cli.prisma.sh/%s-%s-%s-%s.gz"


### PR DESCRIPTION
Upgrade prisma to `v5.5.0` with engine hash `475c616176945d72f4330c92801f0c5e6398dc0f`.