### PR TITLE
chore(prisma): upgrade prisma to v5.5.2

### DIFF
--- a/binaries/binaries.go
+++ b/binaries/binaries.go
@@ -14,11 +14,11 @@ import (
 )
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.5.0"
+const PrismaVersion = "5.5.2"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "475c616176945d72f4330c92801f0c5e6398dc0f"
+const EngineVersion = "aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a"
 
 // PrismaURL points to an S3 bucket URL where the CLI binaries are stored.
 var PrismaURL = "https://packaged-cli.prisma.sh/%s-%s-%s-%s.gz"


### PR DESCRIPTION
Upgrade prisma to `v5.5.2` with engine hash `aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a`.