### PR TITLE
chore(prisma): upgrade prisma to v5.6.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.5.2"
+const PrismaVersion = "5.6.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a"
+const EngineVersion = "e95e739751f42d8ca026f6b910f5a2dc5adeaeee"

--- a/engine/lifecycle.go
+++ b/engine/lifecycle.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -317,9 +316,7 @@ func (e *QueryEngine) spawn(file string) error {
 			Status string `json:"status"`
 		}
 
-		// the response is a JSON in a string, so unquote it
-		unquoted, _ := strconv.Unquote(string(body))
-		if err := json.Unmarshal([]byte(unquoted), &response); err != nil {
+		if err := json.Unmarshal(body, &response); err != nil {
 			connectErr = err
 			logger.Debug.Printf("could not unmarshal response %s; retrying...", body)
 			time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
Upgrade prisma to `v5.6.0` with engine hash `e95e739751f42d8ca026f6b910f5a2dc5adeaeee`.