### PR TITLE
chore(prisma): upgrade prisma to v5.7.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.6.0"
+const PrismaVersion = "5.7.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "e95e739751f42d8ca026f6b910f5a2dc5adeaeee"
+const EngineVersion = "79fb5193cf0a8fdbef536e4b4a159cad677ab1b9"


### PR DESCRIPTION
Upgrade prisma to `v5.7.0` with engine hash `79fb5193cf0a8fdbef536e4b4a159cad677ab1b9`.