### PR TITLE
chore(prisma): upgrade prisma to v5.7.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.7.0"
+const PrismaVersion = "5.7.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "79fb5193cf0a8fdbef536e4b4a159cad677ab1b9"
+const EngineVersion = "0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5"


### PR DESCRIPTION
Upgrade prisma to `v5.7.1` with engine hash `0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5`.