### PR TITLE
chore(prisma): upgrade prisma to v5.8.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.7.1"
+const PrismaVersion = "5.8.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5"
+const EngineVersion = "0a83d8541752d7582de2ebc1ece46519ce72a848"


### PR DESCRIPTION
Upgrade prisma to `v5.8.0` with engine hash `0a83d8541752d7582de2ebc1ece46519ce72a848`.