### PR TITLE
chore(prisma): upgrade prisma to v5.8.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.8.0"
+const PrismaVersion = "5.8.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "0a83d8541752d7582de2ebc1ece46519ce72a848"
+const EngineVersion = "78caf6feeaed953168c64e15a249c3e9a033ebe2"


### PR DESCRIPTION
Upgrade prisma to `v5.8.1` with engine hash `78caf6feeaed953168c64e15a249c3e9a033ebe2`.