### PR TITLE
chore(prisma): upgrade prisma to v5.9.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.9.0"
+const PrismaVersion = "5.9.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v5.9.1` with engine hash `23fdc5965b1e05fc54e5f26ed3de66776b93de64`.