### PR TITLE
chore(prisma): upgrade prisma to v5.10.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.9.1"
+const PrismaVersion = "5.10.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "23fdc5965b1e05fc54e5f26ed3de66776b93de64"
+const EngineVersion = "5a9203d0590c951969e85a7d07215503f4672eb9"


### PR DESCRIPTION
Upgrade prisma to `v5.10.0` with engine hash `5a9203d0590c951969e85a7d07215503f4672eb9`.
Full release notes: [v5.10.0](https://github.com/prisma/prisma/releases/tag/5.10.0).