### PR TITLE
chore(prisma): upgrade prisma to v5.10.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.10.0"
+const PrismaVersion = "5.10.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v5.10.1` with engine hash `5a9203d0590c951969e85a7d07215503f4672eb9`.
Full release notes: [v5.10.1](https://github.com/prisma/prisma/releases/tag/5.10.1).