### PR TITLE
chore(prisma): upgrade prisma to v5.11.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.10.2"
+const PrismaVersion = "5.11.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "5a9203d0590c951969e85a7d07215503f4672eb9"
+const EngineVersion = "efd2449663b3d73d637ea1fd226bafbcf45b3102"


### PR DESCRIPTION
Upgrade prisma to `v5.11.0` with engine hash `efd2449663b3d73d637ea1fd226bafbcf45b3102`.
Full release notes: [v5.11.0](https://github.com/prisma/prisma/releases/tag/5.11.0).