### PR TITLE
chore(prisma): upgrade prisma to v5.12.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.11.0"
+const PrismaVersion = "5.12.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "efd2449663b3d73d637ea1fd226bafbcf45b3102"
+const EngineVersion = "473ed3124229e22d881cb7addf559799debae1ab"


### PR DESCRIPTION
Upgrade prisma to `v5.12.0` with engine hash `473ed3124229e22d881cb7addf559799debae1ab`.
Full release notes: [v5.12.0](https://github.com/prisma/prisma/releases/tag/5.12.0).