### PR TITLE
chore(prisma): upgrade prisma to v5.13.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.12.1"
+const PrismaVersion = "5.13.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "473ed3124229e22d881cb7addf559799debae1ab"
+const EngineVersion = "b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b"


### PR DESCRIPTION
Upgrade prisma to `v5.13.0` with engine hash `b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b`.
Full release notes: [v5.13.0](https://github.com/prisma/prisma/releases/tag/5.13.0).