### PR TITLE
chore(prisma): upgrade prisma to v5.15.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.14.0"
+const PrismaVersion = "5.15.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "e9771e62de70f79a5e1c604a2d7c8e2a0a874b48"
+const EngineVersion = "12e25d8d06f6ea5a0252864dd9a03b1bb51f3022"


### PR DESCRIPTION
Upgrade prisma to `v5.15.0` with engine hash `12e25d8d06f6ea5a0252864dd9a03b1bb51f3022`.
Full release notes: [v5.15.0](https://github.com/prisma/prisma/releases/tag/5.15.0).