### PR TITLE
chore(prisma): upgrade prisma to v5.15.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.15.0"
+const PrismaVersion = "5.15.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "12e25d8d06f6ea5a0252864dd9a03b1bb51f3022"
+const EngineVersion = "5675a3182f972f1a8f31d16eee6abf4fd54910e3"


### PR DESCRIPTION
Upgrade prisma to `v5.15.1` with engine hash `5675a3182f972f1a8f31d16eee6abf4fd54910e3`.
Full release notes: [v5.15.1](https://github.com/prisma/prisma/releases/tag/5.15.1).