### PR TITLE
chore(prisma): upgrade prisma to v5.16.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.15.1"
+const PrismaVersion = "5.16.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "5675a3182f972f1a8f31d16eee6abf4fd54910e3"
+const EngineVersion = "34ace0eb2704183d2c05b60b52fba5c43c13f303"


### PR DESCRIPTION
Upgrade prisma to `v5.16.0` with engine hash `34ace0eb2704183d2c05b60b52fba5c43c13f303`.
Full release notes: [v5.16.0](https://github.com/prisma/prisma/releases/tag/5.16.0).