### PR TITLE
chore(prisma): upgrade prisma to v5.16.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.16.0"
+const PrismaVersion = "5.16.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v5.16.1` with engine hash `34ace0eb2704183d2c05b60b52fba5c43c13f303`.
Full release notes: [v5.16.1](https://github.com/prisma/prisma/releases/tag/5.16.1).