### PR TITLE
chore(prisma): upgrade prisma to v5.16.2

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.16.1"
+const PrismaVersion = "5.16.2"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v5.16.2` with engine hash `34ace0eb2704183d2c05b60b52fba5c43c13f303`.
Full release notes: [v5.16.2](https://github.com/prisma/prisma/releases/tag/5.16.2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Prisma CLI version to `5.16.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->