### PR TITLE
chore(prisma): upgrade prisma to v5.19.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.19.0"
+const PrismaVersion = "5.19.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "5fe21811a6ba0b952a3bc71400666511fe3b902f"
+const EngineVersion = "69d742ee20b815d88e17e54db4a2a7a3b30324e3"


### PR DESCRIPTION
Upgrade prisma to `v5.19.1` with engine hash `69d742ee20b815d88e17e54db4a2a7a3b30324e3`.
Full release notes: [v5.19.1](https://github.com/prisma/prisma/releases/tag/5.19.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to Prisma CLI version 5.19.1, which may include new features and improvements.
	- Enhanced performance and stability with the updated Prisma Engine version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->