### PR TITLE
fix(builder): skip "mode" field when creating uniqueObjectFields

### DIFF
--- a/runtime/builder/builder.go
+++ b/runtime/builder/builder.go
@@ -281,12 +281,18 @@ func checkFields(parent Field, fields []Field) error {
 	uniqueObjectFields := make(map[string]Field)
 	for _, f := range fields {
 		if f.Value != nil && !f.List && !parent.List {
+			if f.Name == "mode" {
+				continue
+			}
+
 			if _, ok := uniqueObjectFields[f.Name]; ok {
 				return fmt.Errorf("%w: %q", ErrDuplicateField, f.Name)
 			}
+
 			uniqueObjectFields[f.Name] = f
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
The "mode" field is now skipped to prevent it from being considered a unique field. This avoids conflicts or errors when processing objects that include the "mode" field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated field validation logic to exclude fields named "mode" from uniqueness checks, improving processing efficiency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->