### PR TITLE
chore(prisma): upgrade prisma to v5.21.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.20.0"
+const PrismaVersion = "5.21.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "06fc58a368dc7be9fbbbe894adf8d445d208c284"
+const EngineVersion = "08713a93b99d58f31485621c634b04983ae01d95"


### PR DESCRIPTION
Upgrade prisma to `v5.21.0` with engine hash `08713a93b99d58f31485621c634b04983ae01d95`.
Full release notes: [v5.21.0](https://github.com/prisma/prisma/releases/tag/5.21.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versions for Prisma CLI and Prisma Engine to enhance performance and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->