### PR TITLE
chore(prisma): upgrade prisma to v5.21.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.21.0"
+const PrismaVersion = "5.21.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "08713a93b99d58f31485621c634b04983ae01d95"
+const EngineVersion = "bf0e5e8a04cada8225617067eaa03d041e2bba36"


### PR DESCRIPTION
Upgrade prisma to `v5.21.1` with engine hash `bf0e5e8a04cada8225617067eaa03d041e2bba36`.
Full release notes: [v5.21.1](https://github.com/prisma/prisma/releases/tag/5.21.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versions for Prisma CLI and Prisma Engine to enhance performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->