### PR TITLE
ci(integration): update macOS version in integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,13 +27,7 @@ jobs:
       # fix for GitHub actions MacOS
       - name: Setup docker
         if: runner.os == 'macos' && steps.changes.outputs.go == 'true'
-        run: |
-          brew install docker
-          colima start
-
-          # For testcontainers to find the Colima socket
-          # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
-          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+        uses: douglascamata/setup-docker-macos-action@v1-alpha
 
       - uses: actions/cache@v4
         with:
@@ -65,17 +59,6 @@ jobs:
               - '**/*.mod'
               - '**/*.sum'
               - '**/*.work'
-
-      # fix for GitHub actions MacOS
-      - name: Setup docker
-        if: runner.os == 'macos' && steps.changes.outputs.go == 'true'
-        run: |
-          brew install docker
-          colima start
-
-          # For testcontainers to find the Colima socket
-          # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
-          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Updated macOS version in integration-test CI workflow from macOS-12 to macOS-13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the macOS version in the integration testing workflow to ensure compatibility with the latest features.
	- Simplified Docker setup process on macOS by utilizing an external action for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->