### PR TITLE
chore(prisma): upgrade prisma to v5.22.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.21.1"
+const PrismaVersion = "5.22.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "bf0e5e8a04cada8225617067eaa03d041e2bba36"
+const EngineVersion = "605197351a3c8bdd595af2d2a9bc3025bca48ea2"


### PR DESCRIPTION
Upgrade prisma to `v5.22.0` with engine hash `605197351a3c8bdd595af2d2a9bc3025bca48ea2`.
Full release notes: [v5.22.0](https://github.com/prisma/prisma/releases/tag/5.22.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Prisma CLI to version 5.22.0, enhancing performance and capabilities.
	- Updated Prisma Engine to a new version, ensuring improved functionality and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->