### PR TITLE
fix(unpack): set environment variable if already unpacked

### DIFF
--- a/binaries/unpack/unpack.go
+++ b/binaries/unpack/unpack.go
@@ -36,6 +36,9 @@ func Unpack(data []byte, name string, version string) {
 	}
 
 	if _, err := os.Stat(file); err == nil {
+		if err := os.Setenv(FileEnv, file); err != nil {
+			panic(err)
+		}
 		logger.Debug.Printf("query engine exists, not unpacking. %s. at %s", time.Since(start), file)
 		return
 	}


### PR DESCRIPTION
Ensure the environment variable is set when the file exists to prevent possible issues with subsequent operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file handling by setting the `PRISMA_INTERNAL_QUERY_ENGINE_PATH` environment variable when a file exists.
  
- **Bug Fixes**
	- Improved the reliability of file operations by ensuring the environment variable is set correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->