### PR TITLE
feat(mongodb): add findRaw, aggregateRaw and runCommandRaw

### DIFF
--- a/engine/request.go
+++ b/engine/request.go
@@ -53,6 +53,8 @@ func (e *QueryEngine) Do(ctx context.Context, payload interface{}, v interface{}
 		return fmt.Errorf("transform response: %w", err)
 	}
 
+	fmt.Println("response.Data.Result", string(response.Data.Result))
+
 	if err := json.Unmarshal(response.Data.Result, v); err != nil {
 		return fmt.Errorf("json data result unmarshal: %w", err)
 	}

--- a/engine/request.go
+++ b/engine/request.go
@@ -53,8 +53,6 @@ func (e *QueryEngine) Do(ctx context.Context, payload interface{}, v interface{}
 		return fmt.Errorf("transform response: %w", err)
 	}
 
-	fmt.Println("response.Data.Result", string(response.Data.Result))
-
 	if err := json.Unmarshal(response.Data.Result, v); err != nil {
 		return fmt.Errorf("json data result unmarshal: %w", err)
 	}

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"encoding/json"
 	"strings"
-	
+
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -79,7 +79,6 @@ func TransformResponse(data []byte) ([]byte, error) {
 		strings.Contains(string(data), `{"$timestamp":`),
 		strings.Contains(string(data), `{"$regularExpression":`),
 		strings.Contains(string(data), `{"$dbPointer":`),
-		strings.Contains(string(data), `{"$date":`),
 		strings.Contains(string(data), `{"$minKey":`),
 		strings.Contains(string(data), `{"$maxKey":`),
 		strings.Contains(string(data), `{"$undefined":`):

--- a/engine/transform.go
+++ b/engine/transform.go
@@ -2,8 +2,9 @@ package engine
 
 import (
 	"encoding/json"
-	"go.mongodb.org/mongo-driver/v2/bson"
 	"strings"
+	
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type Input struct {

--- a/engine/transform_test.go
+++ b/engine/transform_test.go
@@ -20,7 +20,14 @@ func Test_transformResponse(t *testing.T) {
 			data: []byte(`{"columns":["id","email","username","str","strOpt","date","dateOpt","int","intOpt","float","floatOpt","bool","boolOpt"],"types":["string","string","string","string","string","datetime","datetime","int","int","double","double","int","int"],"rows":[["id1","email1","a","str","strOpt","2020-01-01T00:00:00+00:00","2020-01-01T00:00:00+00:00",5,5,5.5,5.5,1,0],["id2","email2","b","str","strOpt","2020-01-01T00:00:00+00:00","2020-01-01T00:00:00+00:00",5,5,5.5,5.5,1,0]]}`),
 		},
 		want: []byte(`[{"bool":1,"boolOpt":0,"date":"2020-01-01T00:00:00+00:00","dateOpt":"2020-01-01T00:00:00+00:00","email":"email1","float":5.5,"floatOpt":5.5,"id":"id1","int":5,"intOpt":5,"str":"str","strOpt":"strOpt","username":"a"},{"bool":1,"boolOpt":0,"date":"2020-01-01T00:00:00+00:00","dateOpt":"2020-01-01T00:00:00+00:00","email":"email2","float":5.5,"floatOpt":5.5,"id":"id2","int":5,"intOpt":5,"str":"str","strOpt":"strOpt","username":"b"}]`),
-	}}
+	},
+		{
+			name: "transform mongo raw response",
+			args: args{
+				data: []byte(`[{"_id":{"$oid":"67347ee4a18fa09750c1085a"},"createdAt":{"$date":"2024-11-13T10:26:44.246Z"},"firstName":"Trua Nguyen","lastName":"Van","email":"truanv@gmail"},{"_id":{"$oid":"67348094597e341917026845"},"email":"truanv@gmail","firstName":"Trua Nguyen","lastName":"Van"},{"_id":{"$oid":"673480d6597e341917026dea"},"email":"truanv@gmail","firstName":"Trua Nguyen","lastName":"Van"},{"_id":{"$oid":"67348265597e34191702904f"},"firstName":"Trua Nguyen ","lastName":"Van","email":"truanv@gmail"},{"_id":{"$oid":"6734827b597e34191702923d"},"email":"truanv@gmail","firstName":"Trua Nguyen ","lastName":"Van"}]`),
+			},
+			want: []byte(`[{"_id":"67347ee4a18fa09750c1085a","createdAt":"2024-11-13T10:26:44.246Z","email":"truanv@gmail","firstName":"Trua Nguyen","id":"67347ee4a18fa09750c1085a","lastName":"Van"},{"_id":"67348094597e341917026845","email":"truanv@gmail","firstName":"Trua Nguyen","id":"67348094597e341917026845","lastName":"Van"},{"_id":"673480d6597e341917026dea","email":"truanv@gmail","firstName":"Trua Nguyen","id":"673480d6597e341917026dea","lastName":"Van"},{"_id":"67348265597e34191702904f","email":"truanv@gmail","firstName":"Trua Nguyen ","id":"67348265597e34191702904f","lastName":"Van"},{"_id":"6734827b597e34191702923d","email":"truanv@gmail","firstName":"Trua Nguyen ","id":"6734827b597e34191702923d","lastName":"Van"}]`),
+		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := TransformResponse(tt.args.data)

--- a/generator/ast/dmmf/dmmf.go
+++ b/generator/ast/dmmf/dmmf.go
@@ -60,18 +60,20 @@ type Mappings struct {
 }
 
 type ModelOperation struct {
-	Model      types.String `json:"model"`
-	Aggregate  types.String `json:"aggregate"`
-	CreateOne  types.String `json:"createOne"`
-	DeleteMany types.String `json:"deleteMany"`
-	DeleteOne  types.String `json:"deleteOne"`
-	FindFirst  types.String `json:"findFirst"`
-	FindMany   types.String `json:"findMany"`
-	FindUnique types.String `json:"findUnique"`
-	GroupBy    types.String `json:"groupBy"`
-	UpdateMany types.String `json:"updateMany"`
-	UpdateOne  types.String `json:"updateOne"`
-	UpsertOne  types.String `json:"upsertOne"`
+	Model        types.String `json:"model"`
+	Aggregate    types.String `json:"aggregate"`
+	CreateOne    types.String `json:"createOne"`
+	DeleteMany   types.String `json:"deleteMany"`
+	DeleteOne    types.String `json:"deleteOne"`
+	FindFirst    types.String `json:"findFirst"`
+	FindMany     types.String `json:"findMany"`
+	FindUnique   types.String `json:"findUnique"`
+	GroupBy      types.String `json:"groupBy"`
+	UpdateMany   types.String `json:"updateMany"`
+	UpdateOne    types.String `json:"updateOne"`
+	UpsertOne    types.String `json:"upsertOne"`
+	FindRaw      types.String `json:"findRaw"`      // MongoDB only
+	AggregateRaw types.String `json:"aggregateRaw"` // MongoDB only
 }
 
 func (m *ModelOperation) Namespace() string {

--- a/generator/run.go
+++ b/generator/run.go
@@ -87,6 +87,7 @@ func generateClient(input *Root) error {
 		"actions/find",
 		"actions/transaction",
 		"actions/upsert",
+		"actions/raw",
 	}
 
 	var templates []*template.Template

--- a/generator/templates/_header.gotpl
+++ b/generator/templates/_header.gotpl
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"testing"
+	"fmt"
 
 	// no-op import for go modules
 	_ "github.com/joho/godotenv"

--- a/generator/templates/actions/raw.gotpl
+++ b/generator/templates/actions/raw.gotpl
@@ -41,7 +41,7 @@
 							})
 					}
 					return v
-    }
+		}
 
 		func (r {{ $ns }}) AggregateRaw(pipeline []interface{}, options ...interface{}) {{ $result }} {
 				var v {{ $result }}
@@ -52,9 +52,9 @@
 				v.query.Model = "{{ $model.Name.String }}"
 
 				parsedPip := []interface{}{}
-        for _, p := range pipeline {
-        		parsedPip = append(parsedPip, fmt.Sprintf("%v", p))
-        }
+				for _, p := range pipeline {
+					parsedPip = append(parsedPip, fmt.Sprintf("%v", p))
+				}
 
 				v.query.Inputs = append(v.query.Inputs, builder.Input{
 					Name:  "pipeline",

--- a/generator/templates/actions/raw.gotpl
+++ b/generator/templates/actions/raw.gotpl
@@ -1,0 +1,88 @@
+{{- /*gotype:github.com/steebchen/prisma-client-go/generator.Root*/ -}}
+
+{{ range $model := $.DMMF.Datamodel.Models }}
+		{{ $name := $model.Name.GoLowerCase }}
+		{{ $ns := (print $name "Actions") }}
+		{{ $result := (print $name "AggregateRaw") }}
+
+		type {{ $result }} struct {
+			query builder.Query
+		}
+
+		func (r {{ $result }}) getQuery() builder.Query {
+			return r.query
+		}
+
+		func (r {{ $result }}) ExtractQuery() builder.Query {
+			return r.query
+		}
+
+		func (r {{ $result }}) with() {}
+		func (r {{ $result }}) {{ $model.Name.GoLowerCase }}Model() {}
+		func (r {{ $result }}) {{ $model.Name.GoLowerCase }}Relation() {}
+
+		func (r {{ $ns }}) FindRaw(filter interface{}, options ...interface{}) {{ $result }} {
+					var v {{ $result }}
+					v.query = builder.NewQuery()
+					v.query.Engine = r.client
+					v.query.Method = "findRaw"
+					v.query.Operation = "query"
+					v.query.Model = "{{ $model.Name.String }}"
+
+					v.query.Inputs = append(v.query.Inputs, builder.Input{
+						Name:  "filter",
+						Value: fmt.Sprintf("%v", filter),
+					})
+
+					if len(options) > 0 {
+							v.query.Inputs = append(v.query.Inputs, builder.Input{
+								Name:  "options",
+								Value: fmt.Sprintf("%v", options[0]),
+							})
+					}
+					return v
+    }
+
+		func (r {{ $ns }}) AggregateRaw(pipeline []interface{}, options ...interface{}) {{ $result }} {
+				var v {{ $result }}
+				v.query = builder.NewQuery()
+				v.query.Engine = r.client
+				v.query.Method = "aggregateRaw"
+				v.query.Operation = "query"
+				v.query.Model = "{{ $model.Name.String }}"
+
+				parsedPip := []interface{}{}
+        for _, p := range pipeline {
+        		parsedPip = append(parsedPip, fmt.Sprintf("%v", p))
+        }
+
+				v.query.Inputs = append(v.query.Inputs, builder.Input{
+					Name:  "pipeline",
+					Value: parsedPip,
+				})
+
+				if len(options) > 0 {
+						v.query.Inputs = append(v.query.Inputs, builder.Input{
+							Name:  "options",
+							Value: fmt.Sprintf("%v", options[0]),
+						})
+				}
+				return v
+		}
+
+		func (r {{ $result }}) Exec(ctx context.Context) ([]{{ $model.Name.GoCase }}Model, error) {
+				var v []{{ $model.Name.GoCase }}Model
+				if err := r.query.Exec(ctx, &v); err != nil {
+					return nil, err
+				}
+				return v, nil
+		}
+
+		func (r {{ $result }}) ExecInner(ctx context.Context) ([]Inner{{ $model.Name.GoCase }}, error) {
+				var v []Inner{{ $model.Name.GoCase }}
+				if err := r.query.Exec(ctx, &v); err != nil {
+					return nil, err
+				}
+				return v, nil
+		}
+{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.mongodb.org/mongo-driver/v2 v2.0.0-beta2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.mongodb.org/mongo-driver/v2 v2.0.0-beta2 h1:PRtbRKwblE8ZfI8qOhofcjn9y8CmKZI7trS5vDMeJX0=
+go.mongodb.org/mongo-driver/v2 v2.0.0-beta2/go.mod h1:UGLb3ZgEzaY0cCbJpH9UFt9B6gEXiTPzsnJS38nBeoU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/runtime/raw/raw.go
+++ b/runtime/raw/raw.go
@@ -49,6 +49,20 @@ func doRaw(engine engine.Engine, action string, query string, params ...interfac
 	return q
 }
 
+func doCommandRaw(engine engine.Engine, action string, cmd string) builder.Query {
+	q := builder.NewQuery()
+	q.Engine = engine
+	q.Operation = "mutation"
+	q.Method = action
+
+	q.Inputs = append(q.Inputs, builder.Input{
+		Name:  "command",
+		Value: cmd,
+	})
+
+	return q
+}
+
 func convertType(input interface{}) string {
 	data, err := json.Marshal(input)
 	if err != nil {

--- a/runtime/raw/run_command_raw.go
+++ b/runtime/raw/run_command_raw.go
@@ -1,0 +1,36 @@
+package raw
+
+import (
+	"context"
+	"fmt"
+	"github.com/steebchen/prisma-client-go/runtime/builder"
+)
+
+func (r Raw) RunCommandRaw(cmd interface{}) RunCommandExec {
+	return RunCommandExec{
+		query: doCommandRaw(r.Engine, "runCommandRaw", fmt.Sprintf("%v", cmd)),
+	}
+}
+
+type RunCommandExec struct {
+	query builder.Query
+}
+
+func (r RunCommandExec) ExtractQuery() builder.Query {
+	return r.query
+}
+
+func (r RunCommandExec) Tx() TxQueryResult {
+	v := NewTxQueryResult()
+	v.query = r.query
+	v.query.TxResult = make(chan []byte, 1)
+	return v
+}
+
+func (r RunCommandExec) Exec(ctx context.Context, into interface{}) error {
+	if err := r.query.Exec(ctx, &into); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/runtime/raw/run_command_raw.go
+++ b/runtime/raw/run_command_raw.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"fmt"
+
 	"github.com/steebchen/prisma-client-go/runtime/builder"
 )
 


### PR DESCRIPTION
Add missing raw mongodb functions (https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/raw-queries):

1. Findraw
2. AggregateRaw
3. RuncommandRaw

Examples: https://github.com/truanguyenvan/prisma-examples-go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced support for MongoDB response handling with new transformation functions.
  - Added raw query capabilities for MongoDB operations.
  - New templates for generating Go code related to raw data model actions.
  - Implemented functionality for executing raw commands within the runtime context.

- **Bug Fixes**
  - Enhanced error handling and query construction logic for better performance.

- **Documentation**
  - Updated dependencies to include MongoDB driver.

These updates enhance the application's ability to handle various data sources and improve overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->