### PR TITLE
#chore(query): exec query string (raw Query Builder)

### DIFF
--- a/runtime/builder/query_string.go
+++ b/runtime/builder/query_string.go
@@ -1,0 +1,49 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"github.com/steebchen/prisma-client-go/engine"
+	"github.com/steebchen/prisma-client-go/engine/protocol"
+	"github.com/steebchen/prisma-client-go/logger"
+	"time"
+)
+
+type QueryString struct {
+	// Engine holds the implementation of how queries are processed
+	Engine engine.Engine
+
+	// Start time of the request for tracing
+	Start time.Time
+
+	// Query string
+	Query string
+
+	TxResult chan []byte
+}
+
+func NewQueryString() QueryString {
+	return QueryString{
+		Start: time.Now(),
+	}
+}
+
+func (q QueryString) Exec(ctx context.Context, into interface{}) error {
+	payload := protocol.GQLRequest{
+		Query:     q.Query,
+		Variables: map[string]interface{}{},
+	}
+	return q.Do(ctx, payload, into)
+}
+
+func (q QueryString) Do(ctx context.Context, payload interface{}, into interface{}) error {
+	if q.Engine == nil {
+		return fmt.Errorf("client.Prisma.Connect() needs to be called before sending queries")
+	}
+
+	err := q.Engine.Do(ctx, payload, into)
+	now := time.Now()
+	totalDuration := now.Sub(q.Start)
+	logger.Debug.Printf("[timing] TOTAL %q", totalDuration)
+	return err
+}

--- a/runtime/raw/query_string.go
+++ b/runtime/raw/query_string.go
@@ -1,0 +1,57 @@
+package raw
+
+import (
+	"context"
+	"github.com/steebchen/prisma-client-go/runtime/builder"
+	"github.com/steebchen/prisma-client-go/runtime/transaction"
+)
+
+func (r Raw) QueryString(query string) QueryStringExec {
+	queryStr := builder.NewQueryString()
+	queryStr.Engine = r.Engine
+	queryStr.Query = query
+
+	return QueryStringExec{
+		query: queryStr,
+	}
+}
+
+type QueryStringExec struct {
+	query builder.QueryString
+}
+
+func (r QueryStringExec) ExtractQuery() builder.QueryString {
+	return r.query
+}
+
+type TxQueryStringResult struct {
+	query  builder.QueryString
+	result *transaction.Result
+}
+
+func NewTxQueryStringResult() TxQueryStringResult {
+	return TxQueryStringResult{
+		result: &transaction.Result{},
+	}
+}
+
+func (r TxQueryStringResult) ExtractQuery() builder.QueryString {
+	return r.query
+}
+
+func (r TxQueryStringResult) IsTx() {}
+
+func (r TxQueryStringResult) Into(v interface{}) error {
+	return r.result.Get(r.query.TxResult, &v)
+}
+
+func (r QueryStringExec) Tx() TxQueryStringResult {
+	v := NewTxQueryStringResult()
+	v.query = r.ExtractQuery()
+	v.query.TxResult = make(chan []byte, 1)
+	return v
+}
+
+func (r QueryStringExec) Exec(ctx context.Context, into interface{}) error {
+	return r.query.Exec(ctx, into)
+}


### PR DESCRIPTION
Add feat to exec query from QueryString (Raw Query Builder)

example:
var users []db.UserModel
client.Prisma.QueryString(`query {result: findManyUser(where:{AND:[{email:{equals:"truanv@gmail",}},{lastName:{equals:"Van",}},],}) {id createdAt firstName lastName email }}`).Exec(ctx, &users); 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced structured management and execution of GraphQL queries with the new `QueryString` functionality.
	- Added support for executing raw queries in a transactional context through the `QueryStringExec` and `TxQueryStringResult` types.

- **Bug Fixes**
	- Improved error handling for uninitialized query engines during execution.

- **Documentation**
	- Enhanced logging for query execution duration to track performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->