### PR TITLE
chore(prisma): upgrade prisma to v6.0.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "5.22.0"
+const PrismaVersion = "6.0.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+const EngineVersion = "5dbef10bdbfb579e07d35cc85fb1518d357cb99e"


### PR DESCRIPTION
Upgrade prisma to `v6.0.0` with engine hash `5dbef10bdbfb579e07d35cc85fb1518d357cb99e`.
Full release notes: [v6.0.0](https://github.com/prisma/prisma/releases/tag/6.0.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to Prisma CLI version 6.0.0, enhancing compatibility and features.
	- Updated Prisma Engine version for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->