### PR TITLE
chore(prisma): upgrade prisma to v6.0.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.0.0"
+const PrismaVersion = "6.0.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v6.0.1` with engine hash `5dbef10bdbfb579e07d35cc85fb1518d357cb99e`.
Full release notes: [v6.0.1](https://github.com/prisma/prisma/releases/tag/6.0.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Prisma CLI to version 6.0.1, ensuring users benefit from the latest features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->