### PR TITLE
chore(prisma): upgrade prisma to v6.1.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.0.1"
+const PrismaVersion = "6.1.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "5dbef10bdbfb579e07d35cc85fb1518d357cb99e"
+const EngineVersion = "11f085a2012c0f4778414c8db2651556ee0ef959"


### PR DESCRIPTION
Upgrade prisma to `v6.1.0` with engine hash `11f085a2012c0f4778414c8db2651556ee0ef959`.
Full release notes: [v6.1.0](https://github.com/prisma/prisma/releases/tag/6.1.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version for Prisma CLI to 6.1.0.
	- Updated version for Prisma Engine to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->