### PR TITLE
chore(prisma): upgrade prisma to v6.2.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.1.0"
+const PrismaVersion = "6.2.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "11f085a2012c0f4778414c8db2651556ee0ef959"
+const EngineVersion = "4123509d24aa4dede1e864b46351bf2790323b69"


### PR DESCRIPTION
Upgrade prisma to `v6.2.0` with engine hash `4123509d24aa4dede1e864b46351bf2790323b69`.
Full release notes: [v6.2.0](https://github.com/prisma/prisma/releases/tag/6.2.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Prisma CLI version from 6.1.0 to 6.2.0
	- Updated Prisma Engine to a new version with the latest commit hash

<!-- end of auto-generated comment: release notes by coderabbit.ai -->