### PR TITLE
chore(prisma): upgrade prisma to v6.2.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.2.0"
+const PrismaVersion = "6.2.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v6.2.1` with engine hash `4123509d24aa4dede1e864b46351bf2790323b69`.
Full release notes: [v6.2.1](https://github.com/prisma/prisma/releases/tag/6.2.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Prisma CLI version from 6.2.0 to 6.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->