### PR TITLE
fix(prisma): handle race condition when disconnecting

### DIFF
--- a/engine/lifecycle.go
+++ b/engine/lifecycle.go
@@ -62,7 +62,9 @@ func (e *QueryEngine) Connect() error {
 }
 
 func (e *QueryEngine) Disconnect() error {
+	e.mu.Lock()
 	e.disconnected = true
+	e.mu.Unlock()
 	logger.Debug.Printf("disconnecting...")
 
 	if platform.Name() == "windows" {

--- a/engine/qe.go
+++ b/engine/qe.go
@@ -54,7 +54,7 @@ type QueryEngine struct {
 	// lastEngineError contains the last received error
 	lastEngineError string
 
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 func (e *QueryEngine) Name() string {

--- a/engine/request.go
+++ b/engine/request.go
@@ -87,10 +87,13 @@ func (e *QueryEngine) Request(ctx context.Context, method string, path string, p
 		return nil, fmt.Errorf("client is not connected yet")
 	}
 
+	e.mu.RLock()
 	if e.disconnected {
+		e.mu.RUnlock()
 		logger.Info.Printf("A query was executed after Disconnect() was called. Make sure to not send any queries after calling .Prisma.Disconnect() the client.")
 		return nil, fmt.Errorf("client is already disconnected")
 	}
+	e.mu.RUnlock()
 
 	requestBody, err := json.Marshal(payload)
 	if err != nil {

--- a/test/misc/goroutines/default_test.go
+++ b/test/misc/goroutines/default_test.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steebchen/prisma-client-go/test"
+	"github.com/steebchen/prisma-client-go/test/helpers/massert"
+)
+
+type cx = context.Context
+type Func func(t *testing.T, client *PrismaClient, ctx cx)
+
+// The purpose of this test is to have a goroutine continuously making queries (whether or not they succeed),
+// and detect race conditions, after disconnecting.
+func TestDisconnectConcurrent(t *testing.T) {
+	test.RunSerial(t, []test.Database{test.MySQL, test.PostgreSQL}, func(t *testing.T, db test.Database, ctx context.Context) {
+		client := NewClient()
+		mockDBName := test.Start(t, db, client.Engine, []string{})
+
+		// Create a record
+		a := "a"
+		b := "b"
+		created, err := client.User.CreateOne(
+			User.A.Set(a),
+			User.B.Set(b),
+			User.ID.Set("123"),
+		).Exec(ctx)
+		if err != nil {
+			t.Fatalf("fail %s", err)
+		}
+
+		expected := &UserModel{
+			InnerUser: InnerUser{
+				ID: "123",
+				A:  a,
+				B:  &b,
+			},
+		}
+
+		massert.Equal(t, expected, created)
+
+		// Query database concurrently
+		closeCh := make(chan struct{})
+		go func() {
+			loop := true
+			for loop {
+				time.Sleep(time.Millisecond * 100)
+				select {
+				case <-closeCh:
+					loop = false
+				default:
+					client.User.FindUnique(User.ID.Equals(created.ID)).Exec(ctx)
+				}
+			}
+		}()
+
+		// Wait, and close the connection
+		time.Sleep(time.Millisecond * 300)
+		test.End(t, db, client.Engine, mockDBName)
+		closeCh <- struct{}{}
+	})
+}

--- a/test/misc/goroutines/default_test.go
+++ b/test/misc/goroutines/default_test.go
@@ -19,7 +19,6 @@ func TestDisconnectConcurrent(t *testing.T) {
 		client := NewClient()
 		mockDBName := test.Start(t, db, client.Engine, []string{})
 
-		// Create a record
 		a := "a"
 		b := "b"
 		created, err := client.User.CreateOne(

--- a/test/misc/goroutines/schema.prisma
+++ b/test/misc/goroutines/schema.prisma
@@ -1,0 +1,17 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("__REPLACE__")
+}
+
+generator db {
+  provider          = "go run github.com/steebchen/prisma-client-go"
+  output            = "."
+  disableGoBinaries = true
+  package           = "db"
+}
+
+model User {
+  id String  @id @default(cuid()) @map("_id")
+  a  String  @db.VarChar(5)
+  b  String? @db.VarChar(50)
+}


### PR DESCRIPTION
### Description
A non-critical race condition was detected when making queries concurrently, and having one goroutine calling disconnect.

### Changelog
* Replacing QueryEngine regular `Mutex` by a `RWutex`
* Read lock whenever reading the `disconnect` property
* Lock whenever writing a value to the `disconnect` property
* New test covering the concurrent queries case

### New behaviour
Whenever we have concurrent queries, every one of them will acquire a non-blocking read lock. Before a goroutine calls the `Disconnect` function, it'll try to acquire a blocking lock, letting goroutines who are in the process of reading the `disconnect` property finish first.

The goroutine that wants to call the `Disconnect` function will then acquire a lock, and write to the `disconnect` property, preventing new readers from accessing the `disconnect` property. 

It then releases the blocking lock, readers can now safely read (even though they'll get an error because the connection is now closed, but at least it is safe now).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added concurrent query handling and thread-safe mechanisms for database operations.

- **Tests**
	- Introduced new test for concurrent database disconnection scenarios.
	- Added test schema for PostgreSQL database testing.

- **Performance**
	- Enhanced concurrency support by implementing read-write mutex for improved thread safety.
	- Optimized locking mechanisms in query engine methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->