### PR TITLE
chore(docs): update @types/react version in package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,14 +16,9 @@
   "devDependencies": {
     "@types/gtag.js": "0.0.20",
     "@types/node": "22.10.5",
-    "@types/react": "npm:types-react@19.0.0-rc.1",
+    "@types/react": "19.0.0",
     "next-sitemap": "4.2.3",
     "pagefind": "1.3.0",
     "typescript": "5.7.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "npm:types-react@19.0.0-rc.1"
-    }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/react': npm:types-react@19.0.0-rc.1
-
 importers:
 
   .:
@@ -16,10 +13,10 @@ importers:
         version: 15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       nextra:
         specifier: 4.0.0-app-router.11
-        version: 4.0.0-app-router.11(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1)(typescript@5.7.3)
+        version: 4.0.0-app-router.11(@types/react@19.0.0)(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       nextra-theme-docs:
         specifier: 4.0.0-app-router.11
-        version: 4.0.0-app-router.11(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.0.0-app-router.11(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1)(typescript@5.7.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1)
+        version: 4.0.0-app-router.11(@types/react@19.0.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.0.0-app-router.11(@types/react@19.0.0)(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -34,8 +31,8 @@ importers:
         specifier: 22.10.5
         version: 22.10.5
       '@types/react':
-        specifier: npm:types-react@19.0.0-rc.1
-        version: types-react@19.0.0-rc.1
+        specifier: 19.0.0
+        version: 19.0.0
       next-sitemap:
         specifier: 4.2.3
         version: 4.2.3(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
@@ -226,7 +223,7 @@ packages:
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
-      '@types/react': npm:types-react@19.0.0-rc.1
+      '@types/react': '>=16'
       react: '>=16'
 
   '@mermaid-js/parser@0.3.0':
@@ -503,6 +500,9 @@ packages:
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
+
+  '@types/react@19.0.0':
+    resolution: {integrity: sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==}
 
   '@types/unist@2.0.8':
     resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
@@ -1675,9 +1675,6 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  types-react@19.0.0-rc.1:
-    resolution: {integrity: sha512-RshndUfqTW6K3STLPis8BtAYCGOkMbtvYsi90gmVNDZBXUyUc5juf2PE9LfS/JmOlUIRO8cWTS/1MTnmhjDqyQ==}
-
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
@@ -1810,7 +1807,7 @@ packages:
     resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
-      '@types/react': npm:types-react@19.0.0-rc.1
+      '@types/react': '>=16.8'
       immer: '>=9.0.6'
       react: '>=16.8'
     peerDependenciesMeta:
@@ -2016,10 +2013,10 @@ snapshots:
       - acorn
       - supports-color
 
-  '@mdx-js/react@3.1.0(react@19.0.0)(types-react@19.0.0-rc.1)':
+  '@mdx-js/react@3.1.0(@types/react@19.0.0)(react@19.0.0)':
     dependencies:
       '@types/mdx': 2.0.8
-      '@types/react': types-react@19.0.0-rc.1
+      '@types/react': 19.0.0
       react: 19.0.0
 
   '@mermaid-js/parser@0.3.0':
@@ -2272,6 +2269,10 @@ snapshots:
   '@types/node@22.10.5':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/react@19.0.0':
+    dependencies:
+      csstype: 3.1.2
 
   '@types/unist@2.0.8': {}
 
@@ -3543,29 +3544,29 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.0.0-app-router.11(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.0.0-app-router.11(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1)(typescript@5.7.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1):
+  nextra-theme-docs@4.0.0-app-router.11(@types/react@19.0.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nextra@4.0.0-app-router.11(@types/react@19.0.0)(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@headlessui/react': 2.1.10(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       clsx: 2.1.1
       next: 15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-themes: 0.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      nextra: 4.0.0-app-router.11(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1)(typescript@5.7.3)
+      nextra: 4.0.0-app-router.11(@types/react@19.0.0)(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       scroll-into-view-if-needed: 3.1.0
       zod: 3.22.3
       zod-validation-error: 3.4.0(zod@3.22.3)
-      zustand: 4.5.5(react@19.0.0)(types-react@19.0.0-rc.1)
+      zustand: 4.5.5(@types/react@19.0.0)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  nextra@4.0.0-app-router.11(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(types-react@19.0.0-rc.1)(typescript@5.7.3):
+  nextra@4.0.0-app-router.11(@types/react@19.0.0)(acorn@8.10.0)(next@15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.5
       '@headlessui/react': 2.1.10(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/mdx': 3.1.0(acorn@8.10.0)
-      '@mdx-js/react': 3.1.0(react@19.0.0)(types-react@19.0.0-rc.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.0.0)(react@19.0.0)
       '@napi-rs/simple-git': 0.1.9
       '@shikijs/twoslash': 1.22.0(typescript@5.7.3)
       '@theguild/remark-mermaid': 0.1.3(react@19.0.0)
@@ -4024,10 +4025,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  types-react@19.0.0-rc.1:
-    dependencies:
-      csstype: 3.1.2
-
   typescript@5.7.3: {}
 
   ufo@1.5.4: {}
@@ -4180,11 +4177,11 @@ snapshots:
 
   zod@3.22.3: {}
 
-  zustand@4.5.5(react@19.0.0)(types-react@19.0.0-rc.1):
+  zustand@4.5.5(@types/react@19.0.0)(react@19.0.0):
     dependencies:
       use-sync-external-store: 1.2.2(react@19.0.0)
     optionalDependencies:
-      '@types/react': types-react@19.0.0-rc.1
+      '@types/react': 19.0.0
       react: 19.0.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Removed unnecessary pnpm override and replaced the version reference for @types/react to the stable 19.0.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development dependency `@types/react` to version 19.0.0
	- Simplified package dependency configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->