### PR TITLE
feat(prisma): introduce CreateOrUpdate function

### DIFF
--- a/generator/templates/actions/upsert.gotpl
+++ b/generator/templates/actions/upsert.gotpl
@@ -109,6 +109,47 @@
 		return v
 	}
 
+	{{ range $dataSource := $.Datasources }}
+		{{ $providerName := $dataSource.Provider }}
+		{{ if ne $providerName "mongodb" }}
+			func (r {{ $result }}) CreateOrUpdate(
+				{{/* TODO re-use */}}
+				{{ range $field := $model.Fields -}}
+					{{- if $field.RequiredOnCreate $model.PrimaryKey -}}
+						_{{ $field.Name.GoLowerCase }} {{ $model.Name.GoCase }}WithPrisma{{ $field.Name.GoCase }}SetParam,
+					{{ end }}
+				{{- end }}
+				optional ...{{ $model.Name.GoCase }}SetParam,
+			) {{ $result }} {
+				var v {{ $result }}
+				v.query = r.query
+
+				var fields []builder.Field
+				{{ range $field := $model.Fields -}}
+					{{- if $field.RequiredOnCreate $model.PrimaryKey -}}
+						fields = append(fields, _{{ $field.Name.GoLowerCase }}.field())
+					{{ end }}
+				{{- end }}
+
+				for _, q := range optional {
+					fields = append(fields, q.field())
+				}
+
+				v.query.Inputs = append(v.query.Inputs, builder.Input{
+					Name:   "create",
+					Fields: fields,
+				})
+
+				v.query.Inputs = append(v.query.Inputs, builder.Input{
+					Name:   "update",
+					Fields: fields,
+				})
+
+				return v
+			}
+		{{ end }}
+	{{ end }}
+
 	func (r {{ $result }}) Exec(ctx context.Context) (*{{ $modelName }}, error) {
 		var v {{ $modelName }}
 		if err := r.query.Exec(ctx, &v); err != nil {

--- a/test/features/upsert/schema.prisma
+++ b/test/features/upsert/schema.prisma
@@ -11,7 +11,8 @@ generator db {
 }
 
 model Post {
-  id    String @id @default(cuid()) @map("_id")
-  title String
-  views Int
+  id          String @id @default(cuid()) @map("_id")
+  title       String
+  views       Int
+  description String?
 }


### PR DESCRIPTION
### Description

`UpsertOne` is a convenient function when we want to create a record if it doesn't exist, or update it when it does exist. All without having to handle the logic to check whether, or not the record exists. To use it we call this way:

```go
actual, err := client.Post.UpsertOne(
	Post.ID.Equals("upsert"),
	).Create(
		Post.Title.Set("title"),
		Post.Views.Set(1),
	).Update(
		Post.Views.Set(2),
	).Exec(ctx)

```

However, sometimes we might have the same fields in `Create` and `Update`, so we need to use:

```go
actual, err := client.Post.UpsertOne(
	Post.ID.Equals("upsert"),
	).Create(
		Post.Title.Set("title"),
		Post.Views.Set(1),
	).Update(
                 Post.Title.Set("title"),
		Post.Views.Set(1),
	).Exec(ctx)

```

This now becomes verbose, so we need a way to make it less verbose. This should close #489.

### Changelog

- Introduced new `CreateOrUpdate` chain that goes with `UpsertOne`.
- Configured new test case to handle `CreateOrUpdate` when record exists, and don't exist.
- Limited the usage of that function to SQL only (we don't generate the `CreateOrUpdate` for mongo)

### New behaviour

We now can use `UpsertOne` this way:

```go
actual, err := client.Post.UpsertOne(
	Post.ID.Equals("upsert"),
).CreateOrUpdate(
	Post.Title.Set("title"),
	Post.Views.Set(2),
).Exec(ctx)

```

This will now automatically **create** the record if it doesn't exist, otherwise, it'll update the specific record pointed by the *where* parameter value.

### Important note

@steebchen
The current logic makes it that if we pass in a primary key like an `ID` to `Update`, it'll fail for `mongo` database as specified in #1446, hence why we panic for `mongo` when using `CreateOrUpdate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `CreateOrUpdate` method for database operations
	- Introduced optional `description` field for Post model

- **Tests**
	- Enhanced test coverage for upsert functionality
	- Added new test cases for `CreateOrUpdate` method across different database types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->