### PR TITLE
chore(prisma): upgrade prisma to v6.3.0

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,8 +1,8 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.2.1"
+const PrismaVersion = "6.3.0"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main
-const EngineVersion = "4123509d24aa4dede1e864b46351bf2790323b69"
+const EngineVersion = "acc0b9dd43eb689cbd20c9470515d719db10d0b0"


### PR DESCRIPTION
Upgrade prisma to `v6.3.0` with engine hash `acc0b9dd43eb689cbd20c9470515d719db10d0b0`.
Full release notes: [v6.3.0](https://github.com/prisma/prisma/releases/tag/6.3.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Upgraded Prisma version from 6.2.1 to 6.3.0
  - Updated Prisma Engine version to a new identifier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->