### PR TITLE
chore(prisma): upgrade prisma to v6.3.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.3.0"
+const PrismaVersion = "6.3.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v6.3.1` with engine hash `acc0b9dd43eb689cbd20c9470515d719db10d0b0`.
Full release notes: [v6.3.1](https://github.com/prisma/prisma/releases/tag/6.3.1).