### PR TITLE
chore(prisma): upgrade prisma to v6.4.1

### DIFF
--- a/binaries/version.go
+++ b/binaries/version.go
@@ -1,7 +1,7 @@
 package binaries
 
 // PrismaVersion is a hardcoded version of the Prisma CLI.
-const PrismaVersion = "6.4.0"
+const PrismaVersion = "6.4.1"
 
 // EngineVersion is a hardcoded version of the Prisma Engine.
 // The versions can be found under https://github.com/prisma/prisma-engines/commits/main


### PR DESCRIPTION
Upgrade prisma to `v6.4.1` with engine hash `a9055b89e58b4b5bfb59600785423b1db3d0e75d`.
Full release notes: [v6.4.1](https://github.com/prisma/prisma/releases/tag/6.4.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CLI tool version from 6.4.0 to 6.4.1 for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->