### PR TITLE
docs: add deprecation notice for Prisma Go client

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@
 
 <hr>
 
+## DEPRECATION NOTICE
+
+The Prisma Go client is going to be deprecated and won't receive upgrades to Prisma v7+. Please see the [deprecation notice](https://github.com/steebchen/prisma-client-go/issues/1542).
+
 ## Description
 
 Prisma Client Go is an **auto-generated query builder** that enables **type-safe** database access and **reduces

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -11,6 +11,14 @@ import styles from "./index.module.css";
 				Go Prisma is an auto-generated query builder that enables type-safe
 				database access and reduces boilerplate.
 			</h2>
+
+			<h2>
+				Deprecation notice
+			</h2>
+			<p>
+				The Prisma Go client is going to be deprecated and won't receive upgrades to Prisma v7+. Please see the <a href="https://github.com/steebchen/prisma-client-go/issues/1542" className={styles.link}>deprecation notice</a>.
+			</p>
+
 			<div className={styles.buttons}>
 				<Link href="/docs" className={styles.btnPrimary}>
 					Read the docs

--- a/docs/content/index.module.css
+++ b/docs/content/index.module.css
@@ -94,3 +94,7 @@ a.btnSecondary {
 	background: white;
 	color: black;
 }
+
+.link {
+	border-bottom: 1px solid black;
+}


### PR DESCRIPTION
Added a deprecation notice to the README and docs, indicating that the Prisma Go client will not receive upgrades to Prisma v7+. Added a link to the official deprecation issue for further details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new deprecation notice highlighting that the Prisma Go client will not receive further upgrades beyond Prisma v7.
- **Style**
  - Enhanced link styling in the documentation for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->